### PR TITLE
h1 heading optimizations for mobile devices

### DIFF
--- a/landing_page/index.html
+++ b/landing_page/index.html
@@ -2,6 +2,7 @@
 <html lang="en" dir="ltr">
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Welcome to #FitDevs</title>
   <!-- Google Fonts -->
 

--- a/landing_page/styles.css
+++ b/landing_page/styles.css
@@ -36,7 +36,7 @@ section{
 /* timeline elements */
 @media (max-width: 767px) {
     .title {
-        padding-left: 80px;
+        padding: 20px 40px;
         text-align: left;
     }
 }

--- a/landing_page/styles.css
+++ b/landing_page/styles.css
@@ -36,7 +36,9 @@ section{
 /* timeline elements */
 @media (max-width: 767px) {
     .title {
-        padding: 20px 40px;
+        padding-top: 10px;
+        padding-bottom: 10px;
+        padding-left: 30px;
         text-align: left;
     }
 }

--- a/landing_page/styles.css
+++ b/landing_page/styles.css
@@ -30,10 +30,16 @@ section{
 /* Title */
 .title{
   font-size: 4em;
-  padding: 80px 100px;
+  text-align: center;
+  padding: 80px;
 }
 /* timeline elements */
-
+@media (max-width: 767px) {
+    .title {
+        padding-left: 80px;
+        text-align: left;
+    }
+}
 body{
   padding-top:20px;
   text-align: center;

--- a/landing_page/styles.css
+++ b/landing_page/styles.css
@@ -36,10 +36,13 @@ section{
 /* timeline elements */
 @media (max-width: 767px) {
     .title {
-        padding-top: 10px;
-        padding-bottom: 10px;
-        padding-left: 30px;
         text-align: left;
+        padding-left: 10px;
+        padding-top: 20px;
+        padding-bottom: 20px;
+    }
+    .overview-1 {
+        padding: 15px;
     }
 }
 body{


### PR DESCRIPTION
Hello there!
I've visited the Support page on my phone and the everything was super tiny.
I checked the code and I saw the viewport was missing.
So, I added it and found out that the 1st heading isn't flowing with the rest of the content.
I presume that's the reason why you wanted to exclude the viewport.
So, I forked the repo and added a media query exclusively for the heading, tested it on my android and iPhone 8 plus.

Take a look at the changes by visiting this link:
[https://charanmn7.github.io/Support/landing_page/index.html](https://charanmn7.github.io/Support/landing_page/index.html)

Merge my request if you like the changes.
If you find it not that effective, fell free to ignore/reject it.

Here are the screenshots of my results:
![safari](https://user-images.githubusercontent.com/103265133/180867979-475ca5b5-e3ad-4500-93c6-5c563e089b13.jpeg)
![chrome](https://user-images.githubusercontent.com/103265133/180867986-c5eb9f3f-3925-4ca7-a865-f9d63da43d1d.jpeg)
.